### PR TITLE
Added the `End` struct to detect _End of stream_.

### DIFF
--- a/src/common/end.rs
+++ b/src/common/end.rs
@@ -1,0 +1,44 @@
+use crate::Consumable;
+use crate::{ConsumeError, ConsumeErrorType};
+
+/// End of stream of tokens.
+///
+/// Will succeed in consumation if the end of string has been reached. Will fail if it has not been
+/// reached.
+///
+/// # Examples
+///
+/// ```
+/// use manger::{consume_struct, Consumable};
+/// use manger::common;
+///
+/// #[derive(PartialEq, Debug)]
+/// struct EncasedInteger(i32);
+/// consume_struct!(
+///     EncasedInteger => [
+///         > '(',
+///         value: i32,
+///         > ')',
+///         : common::End;
+///         (value)
+///     ]
+/// );
+///
+/// assert!(EncasedInteger::consume_from("(42)").is_ok());
+/// assert!(EncasedInteger::consume_from("(42) some leftover tokens").is_err());
+/// ```
+#[derive(Debug, PartialEq)]
+pub struct End;
+
+impl Consumable for End {
+    fn consume_from(source: &str) -> Result<(Self, &str), ConsumeError> {
+        if source.is_empty() {
+            Ok((End, ""))
+        } else {
+            Err(ConsumeError::new_with(ConsumeErrorType::UnexpectedToken {
+                index: 0,
+                token: source.chars().next().unwrap(),
+            }))
+        }
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -15,8 +15,12 @@ pub use digit::Digit;
 #[doc(inline)]
 pub use whitespace::Whitespace;
 
+#[doc(inline)]
+pub use end::End;
+
 mod catch_all;
 mod digit;
+mod end;
 mod one_or_more;
 mod sign;
 mod whitespace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,28 @@ pub trait Consumable: Sized {
             unconsumed: source,
         }
     }
+
+    /// Parse an item of Self.
+    ///
+    /// Attempt to consume the full source and form a item of Self from it. If it succeeds it will
+    /// return that item. If it fails it will return a error.
+    ///
+    /// It is very similar to [std::str::parse].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use manger::Consumable;
+    ///
+    /// let source = "-42";
+    /// let value = i32::consume_all(source)?;
+    ///
+    /// assert_eq!(value, -42);
+    /// # Ok::<(), manger::ConsumeError>(())
+    /// ```
+    fn consume_all(source: &str) -> Result<Self, ConsumeError> {
+        <(Self, crate::common::End)>::consume_from(source).map(|((item, _), _)| item)
+    }
 }
 
 /// Trait which allows for consuming of instances and literals from a string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,6 +650,70 @@ where
     }
 }
 
+/// A wrapper to have default [FromStr][std::str::FromStr] behaviour.
+///
+/// # Examples
+/// ```
+/// use manger::{ consume_struct, Consumable, Parser };
+/// use std::str::FromStr;
+///
+/// struct EncasedInteger(i32);
+/// consume_struct!(
+///     EncasedInteger => [
+///         > '(',
+///         value: i32,
+///         > ')';
+///         (value)
+///     ]
+/// );
+///
+/// let parser = "(-42)".parse::<Parser<EncasedInteger>>()?;
+/// let EncasedInteger(num) = parser.unwrap();
+///
+/// assert_eq!(num, -42);
+/// # Ok::<(), manger::ConsumeError>(())
+/// ```
+#[derive(Debug)]
+pub struct Parser<T>
+where
+    T: Consumable + Sized,
+{
+    value: T,
+}
+
+impl<T> std::str::FromStr for Parser<T>
+where
+    T: Consumable + Sized,
+{
+    type Err = ConsumeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Parser {
+            value: <T>::consume_all(s)?,
+        })
+    }
+}
+
+impl<T> Parser<T>
+where
+    T: Consumable + Sized,
+{
+    /// Get a immutable reference to the parsed value.
+    pub fn get_ref(&self) -> &T {
+        &self.value
+    }
+
+    /// Get a mutable reference to the parsed value.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+
+    /// Unwrap the parser to fetch the parsed value.
+    pub fn unwrap(self) -> T {
+        self.value
+    }
+}
+
 pub mod chars;
 pub mod common;
 mod either;


### PR DESCRIPTION
This allows for using parsing implementations using the rust [`std::str::FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait.